### PR TITLE
Docker Installation Option

### DIFF
--- a/annotator/requirements.txt
+++ b/annotator/requirements.txt
@@ -1,0 +1,12 @@
+click==7.1.2
+Flask==1.1.2
+Flask-Cors==3.0.9
+itsdangerous==1.1.0
+Jinja2==2.11.2
+joblib==0.17.0
+MarkupSafe==1.1.1
+nltk==3.5
+regex==2020.10.28
+six==1.15.0
+tqdm==4.51.0
+Werkzeug==1.0.1

--- a/annotator/server.Dockerfile
+++ b/annotator/server.Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3-slim
+WORKDIR /usr/src/app
+COPY ./requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY ./server.py ./server.py
+EXPOSE 5555
+CMD ["python", "./server.py"]

--- a/annotator/server.py
+++ b/annotator/server.py
@@ -29,4 +29,4 @@ def detokenize():
 
 
 if __name__ == "__main__":
-    app.run(port=5555, debug=True)
+    app.run(host= "0.0.0.0", port=5555, debug=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,17 @@ version: "3.8"
 
 services:
     annotator-server:
-        image: lyihaoo/annotator-server:1
+        build:
+            context: ./annotator
+            dockerfile: server.Dockerfile
+        image: annotator-server
         ports:
             - "5555:5555"
 
     annotator-ui:
-        image: lyihaoo/annotator-ui:1
+        build:
+            context: ./ui
+            dockerfile: ui.Dockerfile
+        image: annotator-ui
         ports:
             - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+
+services:
+    annotator-server:
+        image: lyihaoo/annotator-server:1
+        ports:
+            - "5555:5555"
+
+    annotator-ui:
+        image: lyihaoo/annotator-ui:1
+        ports:
+            - "8080:8080"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,0 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs12
-RUN apt-get update && apt-get install build-essential -y
-WORKDIR /usr/src/app
-COPY . ui/
-WORKDIR /usr/src/app/ui
-RUN yarn install
-CMD ["yarn", "serve"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,7 @@
+FROM nikolaik/python-nodejs:python3.9-nodejs12
+RUN apt-get update && apt-get install build-essential -y
+WORKDIR /usr/src/app
+COPY . ui/
+WORKDIR /usr/src/app/ui
+RUN yarn install
+CMD ["yarn", "serve"]

--- a/ui/ui.Dockerfile
+++ b/ui/ui.Dockerfile
@@ -1,0 +1,7 @@
+FROM nikolaik/python-nodejs:python3.9-nodejs12
+RUN apt-get update && apt-get install build-essential -y
+WORKDIR /usr/src/app
+COPY ./ ui/
+WORKDIR /usr/src/app/ui
+RUN yarn install
+CMD ["yarn", "serve"]


### PR DESCRIPTION
Allows for user to run annotator using Docker Containers without downloading Python libraries/Node.js/npm/yarn.

Use command `docker-compose up` in the directory of the docker-compose.yml file to run the annotator.