### PR TITLE
Fixed wrong formatted string issue

### DIFF
--- a/ui/src/components/AnnotationPage.vue
+++ b/ui/src/components/AnnotationPage.vue
@@ -146,7 +146,7 @@ export default {
         .post("/detokenize", { tokens: this.tm.words })
         .then((res) => {
           this.$store.commit("addAnnotation", [
-            res.data.text,
+            this.currentSentence.text,
             { entities: this.tm.exportAsAnnotation() },
           ]);
           this.currentIndex++;


### PR DESCRIPTION
Previously, the index mapping was not accurate on wrong formatted text so in this change, the original text that has been used to annotate is placed in the annotations which is working perfectly fine now.