### PR TITLE
Added fixes for broken workflows.

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,8 +28,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
     - name: install app dependencies and build it
-      run: yarn && yarn tauri:build
-    - uses: tauri-apps/tauri-action@v0
+      run: yarn --network-timeout 600000 && yarn tauri:build
+    - uses: tauri-apps/tauri-action@v0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
     - name: install app dependencies and build it
-      run: yarn && yarn tauri:build
-    - uses: tauri-apps/tauri-action@v0
+      run: yarn --network-timeout 600000 && yarn tauri:build
+    - uses: tauri-apps/tauri-action@v0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow failures seem to have been caused by two issues:

1. Timeout during fetching of Yarn packages.
   Workaround: yarnpkg/yarn#8242

2. Missing artifacts during creation of the Windows build.
   Workaround: tauri-apps/tauri-action#240

The changes were tested on a fork and the workflows completed successfully several times in a row, so the issue should be fixed.