### PR TITLE
Fix: cursor over tag name fails to tag

### DIFF
--- a/src/components/AnnotationPage.vue
+++ b/src/components/AnnotationPage.vue
@@ -165,6 +165,16 @@ export default {
         start = parseInt(rangeStart.startContainer.parentElement.id.replace("t", ""));
         let offsetEnd = parseInt(rangeEnd.endContainer.parentElement.id.replace("t", ""));
         end = offsetEnd + rangeEnd.endOffset;
+        if(!end){
+          /* 
+            If last node of selected text contains tag name 
+            Fetch the previous node
+          */
+          const endContainerParent = rangeEnd.endContainer.parentNode;
+          const previousNode = endContainerParent.previousSibling;
+          offsetEnd = parseInt(previousNode.parentElement.id.replace("t",""))
+          end = offsetEnd + rangeEnd.endOffset;
+        }
       } catch {
         console.log("selected text were not tokens");
         return;


### PR DESCRIPTION
Usually selected texts have an id which is something like "t34"
and we replace "t" and we get the text based on the number

But when user hovers over the tag and selects the tag we get a null value because the tag element doesn't have any id.

So choosing the element before the tag should fix the issue #94 